### PR TITLE
reveald: update types to normalized log format

### DIFF
--- a/cmd/reveald/config.go
+++ b/cmd/reveald/config.go
@@ -16,6 +16,7 @@ import (
 	s3kawad "github.com/runreveal/reveald/internal/destinations/s3"
 	"github.com/runreveal/reveald/internal/sources/journald"
 	mqttSrckawad "github.com/runreveal/reveald/internal/sources/mqtt"
+	nginx_syslog "github.com/runreveal/reveald/internal/sources/nginx-syslog"
 	"github.com/runreveal/reveald/internal/sources/scanner"
 	"github.com/runreveal/reveald/internal/sources/syslog"
 	"github.com/runreveal/reveald/internal/types"
@@ -31,6 +32,9 @@ func init() {
 	})
 	loader.Register("syslog", func() loader.Builder[kawa.Source[types.Event]] {
 		return &SyslogConfig{}
+	})
+	loader.Register("nginx_syslog", func() loader.Builder[kawa.Source[types.Event]] {
+		return &NginxSyslogConfig{}
 	})
 	loader.Register("journald", func() loader.Builder[kawa.Source[types.Event]] {
 		return &JournaldConfig{}
@@ -71,6 +75,17 @@ func (c *SyslogConfig) Configure() (kawa.Source[types.Event], error) {
 	return syslog.NewSyslogSource(syslog.SyslogCfg{
 		Addr:        c.Addr,
 		ContentType: c.ContentType,
+	}), nil
+}
+
+type NginxSyslogConfig struct {
+	Addr string `json:"addr"`
+}
+
+func (c *NginxSyslogConfig) Configure() (kawa.Source[types.Event], error) {
+	slog.Info("configuring nginx syslog")
+	return nginx_syslog.NewNginxSyslogSource(nginx_syslog.NginxSyslogCfg{
+		Addr: c.Addr,
 	}), nil
 }
 

--- a/cmd/reveald/main.go
+++ b/cmd/reveald/main.go
@@ -64,8 +64,8 @@ func main() {
 func NewRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   path.Base(os.Args[0]),
-		Short: `kawa is an all-in-one event ingestion daemon`,
-		Long: `kawa is an all-in-one event ingestion daemon.
+		Short: `reveald is an all-in-one event ingestion daemon`,
+		Long: `reveald is an all-in-one event ingestion daemon.
 It is designed to be a single binary that can be deployed to a server and	
 configured to receive events from a variety of sources and send them to a 
 variety of destinations.`,

--- a/examples/config.json
+++ b/examples/config.json
@@ -2,26 +2,22 @@
   // this is an example config file for kawa
   // it is parsed using hujson so you can use comments and trailing commas, but
   // is otherwise identical to JSON
-  "sources": [
-    {
-      "type": "syslog",
+  "sources": {
+    "mynginx": {
+      "type": "nginx_syslog",
       "addr": "0.0.0.0:5514",
-      // content-type tells the source how to parse logs received on this
-      // instance of syslog. We may explore using the syslog tag to indicate
-      // the schema as well down the line.
-      "contentType": "application/json; rrtype=nginx-json",
     },
-    {
+    "myjournald": {
       "type": "journald",
     },
-  ],
-  "destinations": [
-    {
+  },
+  "destinations": {
+    "lumbermill": {
       "type": "s3",
       "bucketName": "the-lumber-mill",
       "bucketRegion": "us-west-2",
     },
-    {
+    "runreveal": {
       "type": "runreveal",
       // Replace this webhook URL with your own, created on https://www.runreveal.com
       // as a "Kawa" type source
@@ -31,6 +27,6 @@
       // a valid environment variable name
       // "webhookURL": "$WEBHOOK_URL",
     },
-  ],
+  },
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,17 +8,20 @@ require (
 	github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c
 	github.com/runreveal/lib/loader v0.0.0-20231128193746-50c2ad68891c
 	github.com/spf13/cobra v1.7.0
+	github.com/stretchr/testify v1.8.4
 	gopkg.in/mcuadros/go-syslog.v2 v2.3.0
 )
 
 require (
 	github.com/aws/aws-sdk-go v1.44.313 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.4.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.6 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
@@ -34,4 +37,5 @@ require (
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -97,7 +97,7 @@ func (q *Queue) Run(ctx context.Context) error {
 		Destination: multiDst,
 		Handler:     kawa.Pipe[types.Event](),
 		// NOTE(alan): don't increase parallelism on this processor until we've
-		// verified thread safety thread-safe story.
+		// verified thread safety.
 	}, kawa.Parallelism(1))
 	if err != nil {
 		return err

--- a/internal/sources/journald/journald.go
+++ b/internal/sources/journald/journald.go
@@ -118,7 +118,7 @@ loop:
 		case s.msgC <- kawa.MsgAck[types.Event]{
 			Msg: kawa.Message[types.Event]{
 				Value: types.Event{
-					Timestamp:  ts,
+					EventTime:  ts,
 					SourceType: "journald",
 					RawLog:     bts,
 				},

--- a/internal/sources/mqtt/mqtt.go
+++ b/internal/sources/mqtt/mqtt.go
@@ -34,7 +34,7 @@ func (s *MQTT) Recv(ctx context.Context) (kawa.Message[types.Event], func(), err
 	eventMsg := kawa.Message[types.Event]{
 		Key: msg.Key,
 		Value: types.Event{
-			Timestamp:  time.Now(),
+			EventTime:  time.Now(),
 			SourceType: "mqtt",
 			RawLog:     msg.Value,
 		}, Topic: msg.Topic,

--- a/internal/sources/nginx-syslog/nginx.go
+++ b/internal/sources/nginx-syslog/nginx.go
@@ -1,0 +1,218 @@
+package nginx_syslog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"regexp"
+	"time"
+
+	"log/slog"
+
+	"github.com/runreveal/kawa"
+	"github.com/runreveal/lib/await"
+	"github.com/runreveal/reveald/internal/types"
+	"gopkg.in/mcuadros/go-syslog.v2"
+)
+
+type NginxSyslogCfg struct {
+	Addr string `json:"addr"`
+}
+
+type NginxSyslogSource struct {
+	cfg          NginxSyslogCfg
+	server       *syslog.Server
+	syslogPartsC syslog.LogPartsChannel
+	eventC       chan kawa.Message[types.Event]
+}
+
+func NewNginxSyslogSource(cfg NginxSyslogCfg) *NginxSyslogSource {
+	server := syslog.NewServer()
+	channel := make(syslog.LogPartsChannel)
+	handler := syslog.NewChannelHandler(channel)
+	server.SetFormat(syslog.RFC3164)
+	server.SetHandler(handler)
+	return &NginxSyslogSource{
+		cfg:          cfg,
+		server:       server,
+		syslogPartsC: channel,
+		eventC:       make(chan kawa.Message[types.Event]),
+	}
+}
+
+func (s *NginxSyslogSource) Run(ctx context.Context) error {
+	slog.Info(fmt.Sprintf("starting syslog server on socket %s", s.cfg.Addr))
+	err := s.server.ListenUDP(s.cfg.Addr)
+	if err != nil {
+		return err
+	}
+	err = s.server.Boot()
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.server.Wait()
+		close(done)
+	}()
+
+	run := await.New()
+	run.AddNamed(await.RunFunc(s.recvLoop), "recvLoop")
+	run.AddNamed(await.RunFunc(func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			slog.Info("stopping syslog server")
+			return s.server.Kill()
+		case <-done:
+			return errors.New("syslog server stopped unexpectedly")
+		}
+	}), "syslog")
+	return run.Run(ctx)
+}
+
+func (s *NginxSyslogSource) recvLoop(ctx context.Context) error {
+	for {
+		select {
+		case logParts := <-s.syslogPartsC:
+			if content, ok := logParts["content"]; ok {
+				rawLog := content.(string)
+
+				ts := time.Now().UTC()
+				if timestamp, ok := logParts["timestamp"]; ok {
+					if ts, ok = timestamp.(time.Time); !ok {
+						ts = time.Now().UTC()
+					}
+				}
+
+				// Parse the nginx log
+				entry, err := parseNginxLog(rawLog)
+				if err != nil {
+					fmt.Println("warn: failed to parse nginx log entry")
+					continue
+				}
+
+				entryTime, err := time.Parse("02/Jan/2006:15:04:05 -0700", entry.TimeLocal)
+				if err != nil {
+					fmt.Printf("warn: failed to parse nginx log timestamp: %s\n", entry.TimeLocal)
+				}
+				if !entryTime.IsZero() {
+					ts = entryTime
+				}
+
+				ip, err := netip.ParseAddr(entry.RemoteAddr)
+				if err != nil {
+					fmt.Printf("warn: failed to parse remote address: %s\n", entry.RemoteAddr)
+				}
+				if entry.RemoteUser == "-" {
+					entry.RemoteUser = ""
+				}
+				if entry.HttpReferer == "-" {
+					entry.HttpReferer = ""
+				}
+				if entry.HttpUserAgent == "-" {
+					entry.HttpUserAgent = ""
+				}
+				if entry.BodyBytesSent == "-" {
+					entry.BodyBytesSent = "0"
+				}
+				if entry.Status == "-" {
+					entry.Status = "0"
+				}
+				if entry.Request == "-" {
+					entry.Request = ""
+				}
+
+				log, err := json.Marshal(rawLog)
+				if err != nil {
+					fmt.Println("warn: failed to marshal raw log")
+				}
+
+				msg := kawa.Message[types.Event]{
+					Value: types.Event{
+						SourceType: "nginx-syslog",
+						EventTime:  ts,
+						Src: types.Network{
+							IP: ip,
+						},
+						Actor: types.Actor{
+							Username: entry.RemoteUser,
+						},
+						RawLog: log,
+						Tags: map[string]string{
+							"request":         entry.Request,
+							"status":          entry.Status,
+							"body_bytes":      entry.BodyBytesSent,
+							"http_referer":    entry.HttpReferer,
+							"http_user_agent": entry.HttpUserAgent,
+						},
+					},
+				}
+
+				select {
+				case s.eventC <- msg:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			} else {
+				fmt.Println("warn: found syslog without 'content' key")
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (s *NginxSyslogSource) Recv(ctx context.Context) (kawa.Message[types.Event], func(), error) {
+	for {
+		select {
+		case msg := <-s.eventC:
+			return msg, func() {}, nil
+		case <-ctx.Done():
+			return kawa.Message[types.Event]{}, func() {}, ctx.Err()
+		}
+	}
+
+}
+
+// nginxLogEntry represents a parsed nginx log entry in the default combined
+// log format.
+type nginxLogEntry struct {
+	RemoteAddr    string
+	RemoteUser    string
+	TimeLocal     string
+	Request       string
+	Status        string
+	BodyBytesSent string
+	HttpReferer   string
+	HttpUserAgent string
+}
+
+// log_format combined '$remote_addr - $remote_user [$time_local] '
+//                     '"$request" $status $body_bytes_sent '
+//                     '"$http_referer" "$http_user_agent"';
+
+// parseNginxLog takes a string in nginx combined log format and returns an nginxLogEntry.
+func parseNginxLog(logLine string) (*nginxLogEntry, error) {
+	var nginxLogRegex = regexp.MustCompile(`^(\S+) - (\S+) \[([\w:\/\-\s\+]+)\] "([^"]+)" (\S+) (\S+) "([^"]*)" "([^"]*)"$`)
+	matches := nginxLogRegex.FindStringSubmatch(logLine)
+
+	if matches == nil || len(matches) < 9 {
+		return nil, fmt.Errorf("log line does not match the nginx combined log format")
+	}
+
+	entry := nginxLogEntry{
+		RemoteAddr:    matches[1],
+		RemoteUser:    matches[2],
+		TimeLocal:     matches[3],
+		Request:       matches[4],
+		Status:        matches[5],
+		BodyBytesSent: matches[6],
+		HttpReferer:   matches[7],
+		HttpUserAgent: matches[8],
+	}
+
+	return &entry, nil
+}

--- a/internal/sources/nginx-syslog/nginx_test.go
+++ b/internal/sources/nginx-syslog/nginx_test.go
@@ -1,0 +1,68 @@
+package nginx_syslog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNginxLog(t *testing.T) {
+	// Define test cases
+	var tests = []struct {
+		name    string
+		logLine string
+		want    *nginxLogEntry
+		wantErr bool
+	}{
+		{
+			name:    "StandardLogEntry",
+			logLine: `127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"`,
+			want: &nginxLogEntry{
+				RemoteAddr:    "127.0.0.1",
+				RemoteUser:    "frank",
+				TimeLocal:     "10/Oct/2000:13:55:36 -0700",
+				Request:       "GET /apache_pb.gif HTTP/1.0",
+				Status:        "200",
+				BodyBytesSent: "2326",
+				HttpReferer:   "http://www.example.com/start.html",
+				HttpUserAgent: "Mozilla/4.08 [en] (Win98; I ;Nav)",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "MissingFields",
+			logLine: `- - - [-] "-" - - "-" "-"`,
+			want: &nginxLogEntry{
+				RemoteAddr:    "-",
+				RemoteUser:    "-",
+				TimeLocal:     "-",
+				Request:       "-",
+				Status:        "-",
+				BodyBytesSent: "-",
+				HttpReferer:   "-",
+				HttpUserAgent: "-",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "MalformedEntry",
+			logLine: `This is not a valid log line`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNginxLog(tt.logLine)
+
+			if tt.wantErr {
+				assert.Error(t, err, "Expected an error for test case: %v", tt.name)
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case: %v", tt.name)
+			}
+			assert.Equal(t, tt.want, got, "log should parse as anticipated")
+		})
+	}
+
+}

--- a/internal/sources/scanner/scanner.go
+++ b/internal/sources/scanner/scanner.go
@@ -31,7 +31,7 @@ func (s *Scanner) Recv(ctx context.Context) (kawa.Message[types.Event], func(), 
 	}
 	return kawa.Message[types.Event]{
 		Value: types.Event{
-			Timestamp:  time.Now(),
+			EventTime:  time.Now(),
 			SourceType: "scanner",
 			RawLog:     msg.Value,
 		},

--- a/internal/sources/syslog/syslog.go
+++ b/internal/sources/syslog/syslog.go
@@ -78,10 +78,9 @@ func (s *SyslogSource) Recv(ctx context.Context) (kawa.Message[types.Event], fun
 
 			msg := kawa.Message[types.Event]{
 				Value: types.Event{
-					Timestamp:   ts,
-					SourceType:  "syslog",
-					RawLog:      rawLog,
-					ContentType: s.cfg.ContentType,
+					EventTime:  ts,
+					SourceType: "syslog",
+					RawLog:     rawLog,
 				},
 			}
 			return msg, nil, nil

--- a/internal/sources/windows/eventlog.go
+++ b/internal/sources/windows/eventlog.go
@@ -40,7 +40,7 @@ func (s *EventLog) Recv(ctx context.Context) (kawa.Message[types.Event], func(),
 	eventMsg := kawa.Message[types.Event]{
 		Key: msg.Key,
 		Value: types.Event{
-			Timestamp:  msg.Value.System.TimeCreated.SystemTime,
+			EventTime:  msg.Value.System.TimeCreated.SystemTime,
 			SourceType: "eventlog",
 			RawLog:     rawLog,
 		},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,10 +1,38 @@
 package types
 
-import "time"
+import (
+	"encoding/json"
+	"net/netip"
+	"time"
+)
 
 type Event struct {
-	Timestamp   time.Time `json:"ts"`
-	SourceType  string    `json:"sourceType"`
-	ContentType string    `json:"contentType"`
-	RawLog      []byte    `json:"rawLog"`
+	SourceType string    `json:"sourceType"`
+	EventTime  time.Time `json:"eventTime,omitempty"`
+	EventName  string    `json:"eventName,omitempty"`
+
+	Actor     Actor             `json:"actor,omitempty"`
+	Src       Network           `json:"src,omitempty"`
+	Dst       Network           `json:"dst,omitempty"`
+	Service   Service           `json:"service,omitempty"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	ReadOnly  bool              `json:"readOnly,omitempty"`
+	Resources []json.RawMessage `json:"resources,omitempty"`
+
+	RawLog []byte `json:"rawLog"`
+}
+
+type Actor struct {
+	ID       string `json:"id,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Username string `json:"username,omitempty"`
+}
+
+type Network struct {
+	IP   netip.Addr `json:"ip,omitempty"`
+	Port uint       `json:"port,omitempty"`
+}
+
+type Service struct {
+	Name string `json:"name,omitempty"`
 }


### PR DESCRIPTION
This log format will help us collect logs more transparently throughout the pipeline.  We're moving parsing logic to the client from the server side and it should enable folks to more easily write their own parsers and get the expected results showing up in the platform.

Also adds a new nginx-syslog source which takes advantage of these new properties.

Existing sources should be unaffected except that they're emitting a logs with different json keys.  The server has already been updated to handle this properly.  We're deprecating the kawa source in RunReveal in favor of the strucutred webhook source, but the kawa source will still work with these type changes.