### PR TITLE
Refactor objstore to handle bucket and pathPrefix internally

### DIFF
--- a/examples/journald_to_s3batch_config.json
+++ b/examples/journald_to_s3batch_config.json
@@ -14,7 +14,8 @@
       "s3": {
         "type": "s3",
         "region": "us-east-2",
-        "bucket": "my-logs-bucket"
+        "bucket": "my-logs-bucket",
+        "pathPrefix": "logs"
       }
     }
   }

--- a/internal/destinations/objbatch/s3.go
+++ b/internal/destinations/objbatch/s3.go
@@ -38,9 +38,6 @@ func WithBlobLike(blobLike objstore.BlobLike) Option {
 type ObjectStorage struct {
 	batcher *batch.Destination[types.Event]
 
-	pathPrefix string
-	bucketName string
-
 	batchSize      int
 	flushFrequency time.Duration
 	blobLike       objstore.BlobLike
@@ -103,12 +100,11 @@ func (s *ObjectStorage) Flush(ctx context.Context, msgs []kawa.Message[types.Eve
 		return err
 	}
 
-	key := fmt.Sprintf("%s/%s/%s_%d.gz",
-		s.pathPrefix,
+	key := fmt.Sprintf("%s/%s_%d.gz",
 		time.Now().UTC().Format("2006/01/02/15"),
 		ksuid.New().String(),
 		time.Now().Unix(),
 	)
 
-	return s.objStore.Store(ctx, s.bucketName, key, bytes.NewReader(buf.Bytes()))
+	return s.objStore.Store(ctx, key, bytes.NewReader(buf.Bytes()))
 }

--- a/internal/destinations/objstore/storage_test.go
+++ b/internal/destinations/objstore/storage_test.go
@@ -16,7 +16,9 @@ func TestS3DataStoreStream(t *testing.T) {
 	t.Skip("local test only, requires aws credentials")
 	ctx := context.Background()
 
-	s3, err := NewS3(S3Config{})
+	s3, err := NewS3(S3Config{
+		Bucket: "pfpwfpwwpfwp",
+	})
 	assert.NoError(t, err, "should not error on s3 init")
 
 	objmgr, err := New(s3)
@@ -46,12 +48,12 @@ func TestS3DataStoreStream(t *testing.T) {
 		assert.NoError(t, err, "should not error on close")
 	}()
 
-	err = objmgr.Store(ctx, "pfpwfpwwpfwp", key, pr)
+	err = objmgr.Store(ctx, key, pr)
 	assert.NoError(t, err, "should not error on store")
 
 	t.Log("finished uploading.")
 
-	actualData, err := objmgr.ReadAll(ctx, "pfpwfpwwpfwp", key)
+	actualData, err := objmgr.ReadAll(ctx, key)
 
 	assert.NoError(t, err, "should not error on fetch")
 	assert.Equal(t, 25_000_000, len(actualData), "s3 data should match expected")


### PR DESCRIPTION
## Summary
- Move storage-specific configuration (bucket, pathPrefix) from objbatch to objstore
- Add bucket and pathPrefix fields to S3Config and R2Config
- Update S3 and R2 structs to store these values internally and apply path prefixing
- Remove bucket parameter from all objstore API methods (Store, Read, ReadAll, GetSignedURL)
- Simplify objbatch to only handle batching logic, not storage details
- Update example config to show pathPrefix in S3 section

## Benefits
- **Better separation of concerns**: objbatch handles batching, objstore handles storage specifics
- **Cleaner API**: Storage backends manage their own bucket/path configuration
- **More flexible**: Each storage type can handle paths differently if needed
- **Consistent**: Both S3 and R2 now work identically

## Breaking Changes
- objstore API methods no longer take bucket parameter (handled internally)
- Path prefixing now configured in storage config rather than batch config