### PR TITLE
Add JSON parsing for journald message field

### DIFF
--- a/internal/sources/journald/journald.go
+++ b/internal/sources/journald/journald.go
@@ -307,6 +307,9 @@ func (s *Journald) unescapeMessage(originalBytes []byte, message journalMsg) []b
 	// Replace MESSAGE field with the parsed JSON object
 	journaldData["MESSAGE"] = parsedMessage
 
+	// Add indicator that MESSAGE was successfully parsed as JSON
+	journaldData["_MESSAGE_IS_JSON"] = true
+
 	// Marshal back to JSON
 	modifiedBytes, err := json.Marshal(journaldData)
 	if err != nil {

--- a/internal/sources/journald/journald_test.go
+++ b/internal/sources/journald/journald_test.go
@@ -22,6 +22,7 @@ func TestUnescapeMessage(t *testing.T) {
 			unescapeJSON: true,
 			expected: `{
 				"MESSAGE": {"key":"value","number":123},
+				"_MESSAGE_IS_JSON": true,
 				"__REALTIME_TIMESTAMP": "1234567890",
 				"__CURSOR": "cursor123"
 			}`,
@@ -36,6 +37,7 @@ func TestUnescapeMessage(t *testing.T) {
 			unescapeJSON: true,
 			expected: `{
 				"MESSAGE": {"outer":"{\"inner\":\"value\"}"},
+				"_MESSAGE_IS_JSON": true,
 				"__REALTIME_TIMESTAMP": "1234567890",
 				"__CURSOR": "cursor123"
 			}`,
@@ -50,6 +52,7 @@ func TestUnescapeMessage(t *testing.T) {
 			unescapeJSON: true,
 			expected: `{
 				"MESSAGE": ["item1","item2",123],
+				"_MESSAGE_IS_JSON": true,
 				"__REALTIME_TIMESTAMP": "1234567890",
 				"__CURSOR": "cursor123"
 			}`,
@@ -120,6 +123,7 @@ func TestUnescapeMessage(t *testing.T) {
 			unescapeJSON: true,
 			expected: `{
 				"MESSAGE": {"unicode":"Hello"},
+				"_MESSAGE_IS_JSON": true,
 				"__REALTIME_TIMESTAMP": "1234567890",
 				"__CURSOR": "cursor123"
 			}`,
@@ -151,6 +155,7 @@ func TestUnescapeMessage(t *testing.T) {
 			unescapeJSON: true,
 			expected: `{
 				"MESSAGE": {"key":"value"},
+				"_MESSAGE_IS_JSON": true,
 				"__REALTIME_TIMESTAMP": "1234567890",
 				"__CURSOR": "cursor123",
 				"_HOSTNAME": "testhost",


### PR DESCRIPTION
Add a boolean field _MESSAGE_IS_JSON to the raw log when the MESSAGE field is successfully parsed as JSON from an escaped string. This allows downstream consumers to distinguish between MESSAGE fields that contain JSON objects parsed from escaped strings versus original JSON objects or plain text.

The indicator is only set when:
- UnescapeMessageJSON is enabled
- MESSAGE is originally a string (not already an object/array)
- MESSAGE contains valid JSON that was successfully parsed