### PR TITLE
Add coredns and tetragon source types

### DIFF
--- a/cmd/reveald/config.go
+++ b/cmd/reveald/config.go
@@ -28,6 +28,9 @@ import (
 	"github.com/runreveal/reveald/internal/sources/syslog"
 	"github.com/runreveal/reveald/internal/sources/windows"
 	"github.com/runreveal/reveald/internal/types"
+
+	"github.com/runreveal/reveald/internal/sources/coredns"
+	"github.com/runreveal/reveald/internal/sources/tetragon"
 	// We could register and configure these in their own package
 	// using the init() function.
 	// That would make it easy to "dynamically" enable and disable them at
@@ -59,6 +62,12 @@ func init() {
 	})
 	loader.Register("eventlog", func() loader.Builder[kawa.Source[types.Event]] {
 		return &EventLogConfig{}
+	})
+	loader.Register("coredns", func() loader.Builder[kawa.Source[types.Event]] {
+		return &CoreDNSConfig{}
+	})
+	loader.Register("tetragon", func() loader.Builder[kawa.Source[types.Event]] {
+		return &TetragonConfig{}
 	})
 
 	// ---------------Destinations-------------------------
@@ -263,6 +272,38 @@ func (c *JournaldConfig) Configure() (kawa.Source[types.Event], error) {
 		journald.WithMaxLineLenKB(maxLineLenKB),
 		journald.WithUnescapeMessageJSON(c.UnescapeMessageJSON),
 	), nil
+}
+
+type CoreDNSConfig struct {
+	Path      string `json:"path"`
+	Extension string `json:"extension"`
+}
+
+func (c *CoreDNSConfig) Configure() (kawa.Source[types.Event], error) {
+	slog.Info(fmt.Sprintf("configuring coredns source for path: %s", c.Path))
+	w := file.NewWatcher(
+		file.WithExtension(c.Extension),
+		file.WithPath(c.Path),
+		file.WithHighWatermarkFile(filepath.Join(internal.ConfigDir(), "coredns-hwm.json")),
+		file.WithCommitInterval(5*time.Second),
+	)
+	return coredns.New(w), nil
+}
+
+type TetragonConfig struct {
+	Path      string `json:"path"`
+	Extension string `json:"extension"`
+}
+
+func (c *TetragonConfig) Configure() (kawa.Source[types.Event], error) {
+	slog.Info(fmt.Sprintf("configuring tetragon source for path: %s", c.Path))
+	w := file.NewWatcher(
+		file.WithExtension(c.Extension),
+		file.WithPath(c.Path),
+		file.WithHighWatermarkFile(filepath.Join(internal.ConfigDir(), "tetragon-hwm.json")),
+		file.WithCommitInterval(5*time.Second),
+	)
+	return tetragon.New(w), nil
 }
 
 type MQTTDestConfig struct {

--- a/internal/sources/coredns/coredns.go
+++ b/internal/sources/coredns/coredns.go
@@ -1,0 +1,172 @@
+package coredns
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/runreveal/kawa"
+	"github.com/runreveal/reveald/internal/sources/file"
+	"github.com/runreveal/reveald/internal/types"
+)
+
+// CoreDNS log format (from the log plugin):
+// [INFO] <client_ip>:<client_port> - <query_id> "<qtype> IN <qname> <proto> <query_size> <do_bit> <bufsize>" <rcode> <flags> <rsize> <duration>
+var logRe = regexp.MustCompile(
+	`^\[INFO\] (\S+):(\d+) - (\d+) "(\S+) IN (\S+) (\S+) (\d+) (\S+) (\d+)" (\S+) (\S+) (\d+) ([\d.]+\S+)$`,
+)
+
+// DNSQuery is the structured representation of a CoreDNS log line.
+type DNSQuery struct {
+	ClientIP   string `json:"clientIP"`
+	ClientPort int    `json:"clientPort"`
+	QueryID    int    `json:"queryID"`
+	QueryType  string `json:"queryType"`
+	QueryName  string `json:"queryName"`
+	Protocol   string `json:"protocol"`
+	QuerySize  int    `json:"querySize"`
+	DNSSEC     bool   `json:"dnssec"`
+	BufSize    int    `json:"bufSize"`
+	Rcode      string `json:"rcode"`
+	Flags      string `json:"flags"`
+	RespSize   int    `json:"respSize"`
+	Duration   string `json:"duration"`
+}
+
+type Source struct {
+	watcher *file.Watcher
+}
+
+func New(watcher *file.Watcher) *Source {
+	return &Source{watcher: watcher}
+}
+
+func (s *Source) Run(ctx context.Context) error {
+	return s.watcher.Run(ctx)
+}
+
+func (s *Source) Recv(ctx context.Context) (kawa.Message[types.Event], func(), error) {
+	for {
+		msg, ack, err := s.watcher.Recv(ctx)
+		if err != nil {
+			return msg, ack, err
+		}
+
+		event, ok := parseEvent(msg.Value)
+		if !ok {
+			kawa.Ack(ack)
+			continue
+		}
+
+		msg.Value = event
+		return msg, ack, nil
+	}
+}
+
+func parseEvent(ev types.Event) (types.Event, bool) {
+	content, ts, ok := stripK8sWrapper(ev.RawLog)
+	if !ok {
+		content = string(ev.RawLog)
+	}
+	if !ts.IsZero() {
+		ev.EventTime = ts
+	}
+
+	q, err := parseLogLine(content)
+	if err != nil {
+		slog.Debug(fmt.Sprintf("coredns: skipping non-query line: %s", content))
+		return ev, false
+	}
+
+	raw, err := json.Marshal(q)
+	if err != nil {
+		slog.Error(fmt.Sprintf("coredns: marshal error: %s", err))
+		return ev, false
+	}
+
+	ev.SourceType = "coredns"
+	ev.EventName = "dns_query"
+	ev.Service = types.Service{Name: "coredns"}
+	ev.RawLog = raw
+
+	if ip, err := netip.ParseAddr(q.ClientIP); err == nil {
+		ev.Src = types.Network{IP: ip, Port: uint(q.ClientPort)}
+	}
+
+	ev.Tags = map[string]string{
+		"queryType": q.QueryType,
+		"queryName": q.QueryName,
+		"rcode":     q.Rcode,
+		"protocol":  q.Protocol,
+	}
+
+	return ev, true
+}
+
+func parseLogLine(line string) (*DNSQuery, error) {
+	m := logRe.FindStringSubmatch(line)
+	if m == nil {
+		return nil, fmt.Errorf("no match")
+	}
+
+	clientPort, _ := strconv.Atoi(m[2])
+	queryID, _ := strconv.Atoi(m[3])
+	querySize, _ := strconv.Atoi(m[7])
+	bufSize, _ := strconv.Atoi(m[9])
+	respSize, _ := strconv.Atoi(m[12])
+
+	return &DNSQuery{
+		ClientIP:   m[1],
+		ClientPort: clientPort,
+		QueryID:     queryID,
+		QueryType:   m[4],
+		QueryName:   m[5],
+		Protocol:    m[6],
+		QuerySize:   querySize,
+		DNSSEC:      m[8] == "true",
+		BufSize:     bufSize,
+		Rcode:       m[10],
+		Flags:       m[11],
+		RespSize:    respSize,
+		Duration:    m[13],
+	}, nil
+}
+
+// stripK8sWrapper parses the Kubernetes container log format:
+// <timestamp> <stream> <flag> <content>
+func stripK8sWrapper(raw []byte) (content string, ts time.Time, ok bool) {
+	line := string(raw)
+	// Minimum: "2006-01-02T15:04:05Z stdout F x"
+	if len(line) < 32 {
+		return "", time.Time{}, false
+	}
+
+	// Find first space (end of timestamp)
+	i := strings.IndexByte(line, ' ')
+	if i < 0 {
+		return "", time.Time{}, false
+	}
+	ts, err := time.Parse(time.RFC3339Nano, line[:i])
+	if err != nil {
+		return "", time.Time{}, false
+	}
+
+	// Skip "<stream> <flag> "
+	rest := line[i+1:]
+	// Find "F " or "P " flag
+	j := strings.Index(rest, " F ")
+	if j < 0 {
+		j = strings.Index(rest, " P ")
+	}
+	if j < 0 {
+		return "", time.Time{}, false
+	}
+
+	return rest[j+3:], ts, true
+}

--- a/internal/sources/coredns/coredns_test.go
+++ b/internal/sources/coredns/coredns_test.go
@@ -1,0 +1,145 @@
+package coredns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/runreveal/reveald/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLogLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    *DNSQuery
+		wantErr bool
+	}{
+		{
+			name: "A record NXDOMAIN",
+			line: `[INFO] 127.0.0.1:52890 - 53891 "A IN controlplane.tailscale.com.forge.svc.cluster.local. udp 79 false 1232" NXDOMAIN qr,aa,rd 172 0.000432668s`,
+			want: &DNSQuery{
+				ClientIP:   "127.0.0.1",
+				ClientPort: 52890,
+				QueryID:    53891,
+				QueryType:  "A",
+				QueryName:  "controlplane.tailscale.com.forge.svc.cluster.local.",
+				Protocol:   "udp",
+				QuerySize:  79,
+				DNSSEC:     false,
+				BufSize:    1232,
+				Rcode:      "NXDOMAIN",
+				Flags:      "qr,aa,rd",
+				RespSize:   172,
+				Duration:   "0.000432668s",
+			},
+		},
+		{
+			name: "AAAA record",
+			line: `[INFO] 127.0.0.1:47534 - 33852 "AAAA IN controlplane.tailscale.com.forge.svc.cluster.local. udp 79 false 1232" NXDOMAIN qr,aa,rd 172 0.000718378s`,
+			want: &DNSQuery{
+				ClientIP:   "127.0.0.1",
+				ClientPort: 47534,
+				QueryID:    33852,
+				QueryType:  "AAAA",
+				QueryName:  "controlplane.tailscale.com.forge.svc.cluster.local.",
+				Protocol:   "udp",
+				QuerySize:  79,
+				DNSSEC:     false,
+				BufSize:    1232,
+				Rcode:      "NXDOMAIN",
+				Flags:      "qr,aa,rd",
+				RespSize:   172,
+				Duration:   "0.000718378s",
+			},
+		},
+		{
+			name:    "non-query line",
+			line:    "CoreDNS-1.13.1",
+			wantErr: true,
+		},
+		{
+			name:    "empty line",
+			line:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLogLine(tt.line)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripK8sWrapper(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantContent string
+		wantOK      bool
+	}{
+		{
+			name:        "standard stdout",
+			raw:         `2026-03-14T23:59:55.039299535Z stdout F [INFO] 127.0.0.1:52890 - 53891 "A IN example.com. udp 40 false 1232" NOERROR qr,rd 56 0.001s`,
+			wantContent: `[INFO] 127.0.0.1:52890 - 53891 "A IN example.com. udp 40 false 1232" NOERROR qr,rd 56 0.001s`,
+			wantOK:      true,
+		},
+		{
+			name:        "stderr line",
+			raw:         `2026-03-14T23:59:54.914952715Z stderr F some error message`,
+			wantContent: "some error message",
+			wantOK:      true,
+		},
+		{
+			name:   "not k8s format",
+			raw:    `just a plain line`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, ts, ok := stripK8sWrapper([]byte(tt.raw))
+			require.Equal(t, tt.wantOK, ok)
+			if ok {
+				require.Equal(t, tt.wantContent, content)
+				require.False(t, ts.IsZero())
+			}
+		})
+	}
+}
+
+func TestParseEvent(t *testing.T) {
+	raw := `2026-03-14T23:59:55.039299535Z stdout F [INFO] 127.0.0.1:52890 - 53891 "A IN example.com. udp 40 false 1232" NOERROR qr,rd 56 0.001234s`
+
+	ev := types.Event{
+		EventTime:  time.Now(),
+		SourceType: "file",
+		RawLog:     []byte(raw),
+	}
+
+	got, ok := parseEvent(ev)
+	require.True(t, ok)
+	require.Equal(t, "coredns", got.SourceType)
+	require.Equal(t, "dns_query", got.EventName)
+	require.Equal(t, "coredns", got.Service.Name)
+	require.Equal(t, "127.0.0.1", got.Src.IP.String())
+	require.Equal(t, uint(52890), got.Src.Port)
+	require.Equal(t, "A", got.Tags["queryType"])
+	require.Equal(t, "example.com.", got.Tags["queryName"])
+	require.Equal(t, "NOERROR", got.Tags["rcode"])
+}
+
+func TestParseEvent_SkipsNonQuery(t *testing.T) {
+	raw := `2026-03-14T23:59:54.914952715Z stdout F CoreDNS-1.13.1`
+	ev := types.Event{RawLog: []byte(raw)}
+	_, ok := parseEvent(ev)
+	require.False(t, ok)
+}

--- a/internal/sources/tetragon/tetragon.go
+++ b/internal/sources/tetragon/tetragon.go
@@ -1,0 +1,218 @@
+package tetragon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/runreveal/kawa"
+	"github.com/runreveal/reveald/internal/sources/file"
+	"github.com/runreveal/reveald/internal/types"
+)
+
+type Source struct {
+	watcher *file.Watcher
+}
+
+func New(watcher *file.Watcher) *Source {
+	return &Source{watcher: watcher}
+}
+
+func (s *Source) Run(ctx context.Context) error {
+	return s.watcher.Run(ctx)
+}
+
+func (s *Source) Recv(ctx context.Context) (kawa.Message[types.Event], func(), error) {
+	for {
+		msg, ack, err := s.watcher.Recv(ctx)
+		if err != nil {
+			return msg, ack, err
+		}
+
+		event, ok := parseEvent(msg.Value)
+		if !ok {
+			kawa.Ack(ack)
+			continue
+		}
+
+		msg.Value = event
+		return msg, ack, nil
+	}
+}
+
+func parseEvent(ev types.Event) (types.Event, bool) {
+	content, ts, ok := stripK8sWrapper(ev.RawLog)
+	if !ok {
+		content = string(ev.RawLog)
+	}
+	if !ts.IsZero() {
+		ev.EventTime = ts
+	}
+
+	// Must be JSON starting with process_kprobe
+	if len(content) == 0 || content[0] != '{' {
+		return ev, false
+	}
+
+	var raw kprobeEvent
+	if err := json.Unmarshal([]byte(content), &raw); err != nil {
+		slog.Debug(fmt.Sprintf("tetragon: json parse error: %s", err))
+		return ev, false
+	}
+
+	kp := raw.ProcessKprobe
+	if kp == nil {
+		return ev, false
+	}
+
+	// Use the event timestamp if available
+	if raw.Time != "" {
+		if t, err := time.Parse(time.RFC3339Nano, raw.Time); err == nil {
+			ev.EventTime = t
+		}
+	}
+
+	ev.SourceType = "tetragon"
+	ev.EventName = kp.FunctionName
+	ev.Service = types.Service{Name: processName(kp.Process)}
+
+	// Extract network info from sock_arg
+	if sa := firstSockArg(kp.Args); sa != nil {
+		if ip, err := netip.ParseAddr(sa.Saddr); err == nil {
+			ev.Src = types.Network{IP: ip, Port: uint(sa.Sport)}
+		}
+		if ip, err := netip.ParseAddr(sa.Daddr); err == nil {
+			ev.Dst = types.Network{IP: ip, Port: uint(sa.Dport)}
+		}
+	}
+
+	// Build tags from pod metadata
+	tags := make(map[string]string)
+	if kp.PolicyName != "" {
+		tags["policyName"] = kp.PolicyName
+	}
+	if p := kp.Process; p != nil {
+		tags["binary"] = p.Binary
+		if p.Pod != nil {
+			tags["podNamespace"] = p.Pod.Namespace
+			tags["podName"] = p.Pod.Name
+			if p.Pod.Container != nil {
+				tags["container"] = p.Pod.Container.Name
+			}
+			if p.Pod.Workload != "" {
+				tags["workload"] = p.Pod.Workload
+			}
+		}
+	}
+	if sa := firstSockArg(kp.Args); sa != nil {
+		tags["protocol"] = sa.Protocol
+		tags["family"] = sa.Family
+	}
+	ev.Tags = tags
+
+	// Keep the original Tetragon JSON as rawLog (already clean JSON)
+	ev.RawLog = []byte(content)
+
+	return ev, true
+}
+
+func processName(p *process) string {
+	if p == nil {
+		return ""
+	}
+	// Return just the binary name, not the full path
+	parts := strings.Split(p.Binary, "/")
+	return parts[len(parts)-1]
+}
+
+func firstSockArg(args []arg) *sockArg {
+	for _, a := range args {
+		if a.SockArg != nil {
+			return a.SockArg
+		}
+	}
+	return nil
+}
+
+// stripK8sWrapper parses the Kubernetes container log format:
+// <timestamp> <stream> <flag> <content>
+func stripK8sWrapper(raw []byte) (content string, ts time.Time, ok bool) {
+	line := string(raw)
+	if len(line) < 32 {
+		return "", time.Time{}, false
+	}
+
+	i := strings.IndexByte(line, ' ')
+	if i < 0 {
+		return "", time.Time{}, false
+	}
+	ts, err := time.Parse(time.RFC3339Nano, line[:i])
+	if err != nil {
+		return "", time.Time{}, false
+	}
+
+	rest := line[i+1:]
+	j := strings.Index(rest, " F ")
+	if j < 0 {
+		j = strings.Index(rest, " P ")
+	}
+	if j < 0 {
+		return "", time.Time{}, false
+	}
+
+	return rest[j+3:], ts, true
+}
+
+// Tetragon JSON types — only the fields we need.
+
+type kprobeEvent struct {
+	ProcessKprobe *processKprobe `json:"process_kprobe"`
+	NodeName      string         `json:"node_name"`
+	Time          string         `json:"time"`
+}
+
+type processKprobe struct {
+	Process      *process `json:"process"`
+	FunctionName string   `json:"function_name"`
+	Args         []arg    `json:"args"`
+	Action       string   `json:"action"`
+	PolicyName   string   `json:"policy_name"`
+}
+
+type process struct {
+	ExecID    string `json:"exec_id"`
+	PID       int    `json:"pid"`
+	Binary    string `json:"binary"`
+	Arguments string `json:"arguments"`
+	Pod       *pod   `json:"pod"`
+}
+
+type pod struct {
+	Namespace string     `json:"namespace"`
+	Name      string     `json:"name"`
+	Container *container `json:"container"`
+	Workload  string     `json:"workload"`
+}
+
+type container struct {
+	Name string `json:"name"`
+}
+
+type arg struct {
+	SockArg *sockArg `json:"sock_arg,omitempty"`
+	IntArg  *int     `json:"int_arg,omitempty"`
+}
+
+type sockArg struct {
+	Family   string `json:"family"`
+	Type     string `json:"type"`
+	Protocol string `json:"protocol"`
+	Saddr    string `json:"saddr"`
+	Daddr    string `json:"daddr"`
+	Sport    int    `json:"sport"`
+	Dport    int    `json:"dport"`
+}

--- a/internal/sources/tetragon/tetragon_test.go
+++ b/internal/sources/tetragon/tetragon_test.go
@@ -1,0 +1,114 @@
+package tetragon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/runreveal/reveald/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleUDPSendmsg = `2026-03-15T00:06:32.475152409Z stdout F {"process_kprobe":{"process":{"exec_id":"abc123","pid":50884,"uid":65532,"cwd":"/","binary":"/coredns","arguments":"-conf /etc/coredns/Corefile","flags":"execve","start_time":"2026-03-14T23:59:53Z","pod":{"namespace":"forge","name":"forge-dns","container":{"id":"containerd://abc","name":"dns-logger"},"workload":"forge-dns"}},"parent":{},"function_name":"udp_sendmsg","args":[{"sock_arg":{"family":"AF_INET","type":"SOCK_DGRAM","protocol":"IPPROTO_UDP","saddr":"10.244.0.30","daddr":"10.96.0.10","sport":45729,"dport":53}},{"int_arg":69}],"action":"KPROBE_ACTION_POST","policy_name":"network-monitor"},"node_name":"kubez-control-plane","time":"2026-03-15T00:06:31.621475905Z"}`
+
+const sampleTCPConnect = `2026-03-15T00:06:32.475522327Z stdout F {"process_kprobe":{"process":{"exec_id":"def456","pid":56384,"uid":1000,"cwd":"/home/forge/workspace","binary":"/usr/local/bin/go","arguments":"build -o /tmp/forge-test ./cmd/forge/","flags":"execve","start_time":"2026-03-15T00:06:31Z","pod":{"namespace":"forge","name":"forge-build","container":{"id":"containerd://xyz","name":"forge"},"workload":"forge-build"}},"function_name":"tcp_connect","args":[{"sock_arg":{"family":"AF_INET","type":"SOCK_STREAM","protocol":"IPPROTO_TCP","saddr":"10.244.0.30","daddr":"142.250.80.46","sport":54321,"dport":443}}],"action":"KPROBE_ACTION_POST","policy_name":"network-monitor"},"node_name":"kubez-control-plane","time":"2026-03-15T00:06:31.800000000Z"}`
+
+func TestParseEvent_UDPSendmsg(t *testing.T) {
+	ev := types.Event{
+		EventTime:  time.Now(),
+		SourceType: "file",
+		RawLog:     []byte(sampleUDPSendmsg),
+	}
+
+	got, ok := parseEvent(ev)
+	require.True(t, ok)
+	require.Equal(t, "tetragon", got.SourceType)
+	require.Equal(t, "udp_sendmsg", got.EventName)
+	require.Equal(t, "coredns", got.Service.Name)
+
+	require.Equal(t, "10.244.0.30", got.Src.IP.String())
+	require.Equal(t, uint(45729), got.Src.Port)
+	require.Equal(t, "10.96.0.10", got.Dst.IP.String())
+	require.Equal(t, uint(53), got.Dst.Port)
+
+	require.Equal(t, "network-monitor", got.Tags["policyName"])
+	require.Equal(t, "/coredns", got.Tags["binary"])
+	require.Equal(t, "forge", got.Tags["podNamespace"])
+	require.Equal(t, "forge-dns", got.Tags["podName"])
+	require.Equal(t, "dns-logger", got.Tags["container"])
+	require.Equal(t, "IPPROTO_UDP", got.Tags["protocol"])
+
+	// EventTime should be from the Tetragon event time
+	expected, _ := time.Parse(time.RFC3339Nano, "2026-03-15T00:06:31.621475905Z")
+	require.Equal(t, expected, got.EventTime)
+}
+
+func TestParseEvent_TCPConnect(t *testing.T) {
+	ev := types.Event{
+		EventTime:  time.Now(),
+		SourceType: "file",
+		RawLog:     []byte(sampleTCPConnect),
+	}
+
+	got, ok := parseEvent(ev)
+	require.True(t, ok)
+	require.Equal(t, "tetragon", got.SourceType)
+	require.Equal(t, "tcp_connect", got.EventName)
+	require.Equal(t, "go", got.Service.Name)
+
+	require.Equal(t, "10.244.0.30", got.Src.IP.String())
+	require.Equal(t, uint(54321), got.Src.Port)
+	require.Equal(t, "142.250.80.46", got.Dst.IP.String())
+	require.Equal(t, uint(443), got.Dst.Port)
+}
+
+func TestParseEvent_SkipsNonKprobe(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "plain text log",
+			raw:  `2026-03-15T22:07:38.691246Z stdout F I0315 22:07:38.691246       1 main.go:297] Handling node`,
+		},
+		{
+			name: "non-json",
+			raw:  `2026-03-15T22:07:38.691246Z stdout F not json at all`,
+		},
+		{
+			name: "json without process_kprobe",
+			raw:  `2026-03-15T00:00:00Z stdout F {"process_exec":{"process":{"binary":"/bin/bash"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := types.Event{RawLog: []byte(tt.raw)}
+			_, ok := parseEvent(ev)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestStripK8sWrapper(t *testing.T) {
+	raw := `2026-03-15T00:06:32.475152409Z stdout F {"some":"json"}`
+	content, ts, ok := stripK8sWrapper([]byte(raw))
+	require.True(t, ok)
+	require.Equal(t, `{"some":"json"}`, content)
+	require.False(t, ts.IsZero())
+}
+
+func TestProcessName(t *testing.T) {
+	tests := []struct {
+		binary string
+		want   string
+	}{
+		{"/usr/local/bin/go", "go"},
+		{"/coredns", "coredns"},
+		{"binary", "binary"},
+	}
+	for _, tt := range tests {
+		got := processName(&process{Binary: tt.binary})
+		require.Equal(t, tt.want, got)
+	}
+	require.Equal(t, "", processName(nil))
+}


### PR DESCRIPTION
## Summary
- Adds CoreDNS source that parses structured DNS query logs from Kubernetes container log files (K8s wrapper + CoreDNS log plugin format)
- Adds Tetragon source that parses kprobe network events (process_kprobe JSON) for tcp_connect and udp_sendmsg visibility
- Both sources use the existing file watcher infrastructure and register in the loader config
- Includes tests for log parsing, K8s wrapper stripping, and event construction

## Test plan
- [ ] `go test ./internal/sources/coredns/...`
- [ ] `go test ./internal/sources/tetragon/...`
- [ ] `go build ./cmd/reveald/`
- [ ] Deploy to forge kind cluster and verify logs flow through to RunReveal