### PR TITLE
feat: Windows SCM service support and event log parsing

### DIFF
--- a/cmd/reveald/main.go
+++ b/cmd/reveald/main.go
@@ -113,51 +113,52 @@ func NewRunCommand() *cobra.Command {
 				return err
 			}
 
-			w := await.New(await.WithSignals, await.WithStopTimeout(30*time.Second))
-
-			// if config.Monitoring.Addr != "" {
-			// 	mux := http.NewServeMux()
-			// 	if config.Monitoring.PProf.Path != "" {
-			// 		prefix := config.Monitoring.PProf.Path
-			// 		http.HandleFunc(prefix, pprof.Index)
-			// 		http.HandleFunc(prefix+"cmdline", pprof.Cmdline)
-			// 		http.HandleFunc(prefix+"profile", pprof.Profile)
-			// 		http.HandleFunc(prefix+"symbol", pprof.Symbol)
-			// 		http.HandleFunc(prefix+"trace", pprof.Trace)
-			// 	}
-			// 	if config.Monitoring.Metrics.Path != "" {
-			// 		mux.Handle(config.Monitoring.Metrics.Path, promhttp.Handler())
-			// 	}
-			// 	server := &http.Server{Addr: config.Monitoring.Addr, Handler: mux}
-			// 	w.AddNamed(await.ListenAndServe(server), "monitoring")
-			// }
-
 			slog.Info(fmt.Sprintf("config: %+v", config))
 
-			ctx := context.Background()
-			srcs := map[string]queue.Source{}
-			for k, v := range config.Sources {
-				src, err := v.Configure()
-				if err != nil {
-					return err
-				}
-				srcs[k] = queue.Source{Name: k, Source: src}
-			}
+			return runService("reveald", func(ctx context.Context) error {
+				w := await.New(await.WithSignals, await.WithStopTimeout(30*time.Second))
 
-			dsts := map[string]queue.Destination{}
-			for k, v := range config.Destinations {
-				dst, err := v.Configure()
-				if err != nil {
-					return err
-				}
-				dsts[k] = queue.Destination{Name: k, Destination: dst}
-			}
+				// if config.Monitoring.Addr != "" {
+				// 	mux := http.NewServeMux()
+				// 	if config.Monitoring.PProf.Path != "" {
+				// 		prefix := config.Monitoring.PProf.Path
+				// 		http.HandleFunc(prefix, pprof.Index)
+				// 		http.HandleFunc(prefix+"cmdline", pprof.Cmdline)
+				// 		http.HandleFunc(prefix+"profile", pprof.Profile)
+				// 		http.HandleFunc(prefix+"symbol", pprof.Symbol)
+				// 		http.HandleFunc(prefix+"trace", pprof.Trace)
+				// 	}
+				// 	if config.Monitoring.Metrics.Path != "" {
+				// 		mux.Handle(config.Monitoring.Metrics.Path, promhttp.Handler())
+				// 	}
+				// 	server := &http.Server{Addr: config.Monitoring.Addr, Handler: mux}
+				// 	w.AddNamed(await.ListenAndServe(server), "monitoring")
+				// }
 
-			q := queue.New(queue.WithSources(srcs), queue.WithDestinations(dsts))
-			w.AddNamed(q, "queue")
-			err = w.Run(ctx)
-			slog.Error(fmt.Sprintf("closing: %+v", err))
-			return err
+				srcs := map[string]queue.Source{}
+				for k, v := range config.Sources {
+					src, err := v.Configure()
+					if err != nil {
+						return err
+					}
+					srcs[k] = queue.Source{Name: k, Source: src}
+				}
+
+				dsts := map[string]queue.Destination{}
+				for k, v := range config.Destinations {
+					dst, err := v.Configure()
+					if err != nil {
+						return err
+					}
+					dsts[k] = queue.Destination{Name: k, Destination: dst}
+				}
+
+				q := queue.New(queue.WithSources(srcs), queue.WithDestinations(dsts))
+				w.AddNamed(q, "queue")
+				err := w.Run(ctx)
+				slog.Error(fmt.Sprintf("closing: %+v", err))
+				return err
+			})
 		},
 	}
 

--- a/cmd/reveald/service_other.go
+++ b/cmd/reveald/service_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package main
+
+import "context"
+
+// runService on non-Windows platforms just calls fn directly.
+func runService(_ string, fn func(ctx context.Context) error) error {
+	return fn(context.Background())
+}

--- a/cmd/reveald/service_windows.go
+++ b/cmd/reveald/service_windows.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// runService detects whether the process is running as a Windows service.
+// If so, it runs fn under the Service Control Manager. Otherwise it calls
+// fn directly with a background context (normal interactive mode).
+func runService(serviceName string, fn func(ctx context.Context) error) error {
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		return fmt.Errorf("detecting service mode: %w", err)
+	}
+	if !isService {
+		return fn(context.Background())
+	}
+
+	slog.Info("running as Windows service", "service", serviceName)
+	return svc.Run(serviceName, &serviceHandler{fn: fn})
+}
+
+type serviceHandler struct {
+	fn func(ctx context.Context) error
+}
+
+func (h *serviceHandler) Execute(
+	args []string,
+	r <-chan svc.ChangeRequest,
+	s chan<- svc.Status,
+) (svcSpecificEC bool, exitCode uint32) {
+	s <- svc.Status{State: svc.StartPending}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- h.fn(ctx)
+	}()
+
+	s <- svc.Status{
+		State:   svc.Running,
+		Accepts: svc.AcceptStop | svc.AcceptShutdown,
+	}
+
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				s <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				s <- svc.Status{State: svc.StopPending}
+				cancel()
+				<-done
+				return false, 0
+			}
+		case err := <-done:
+			if err != nil {
+				slog.Error("service exited with error", "err", err)
+				return true, 1
+			}
+			return false, 0
+		}
+	}
+}

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -1,0 +1,229 @@
+# Windows Event Log Collection with Reveald
+
+This guide covers setting up reveald to collect Windows event logs and ship them to RunReveal.
+
+## Prerequisites
+
+- Windows Server 2019+ or Windows 10+
+- Administrator access
+- A RunReveal workspace with a reveald webhook source
+
+## 1. Install Sysmon
+
+Sysmon provides detailed system telemetry that goes well beyond the built-in
+Windows event logs. It captures process creation with full command lines, network
+connections tied to processes, DNS queries, file and registry changes, and more.
+
+Download and install Sysmon with the
+[sysmon-modular](https://github.com/olafhartong/sysmon-modular) config:
+
+```powershell
+# Download Sysmon
+Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Sysmon.zip" -OutFile "$env:TEMP\Sysmon.zip"
+Expand-Archive -Path "$env:TEMP\Sysmon.zip" -DestinationPath "$env:TEMP\Sysmon" -Force
+
+# Download sysmon-modular config
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/olafhartong/sysmon-modular/master/sysmonconfig.xml" -OutFile "$env:TEMP\Sysmon\sysmonconfig.xml"
+
+# Install
+& "$env:TEMP\Sysmon\Sysmon64.exe" -accepteula -i "$env:TEMP\Sysmon\sysmonconfig.xml"
+```
+
+Verify it's running:
+
+```powershell
+Get-Service Sysmon64
+```
+
+## 2. Enable Windows Audit Policies
+
+These policies enable the built-in Windows security events that complement Sysmon.
+
+```powershell
+# Process tracking
+auditpol /set /subcategory:"Process Creation" /success:enable /failure:enable
+auditpol /set /subcategory:"Process Termination" /success:enable
+
+# Logon/Logoff
+auditpol /set /subcategory:"Logon" /success:enable /failure:enable
+auditpol /set /subcategory:"Logoff" /success:enable
+auditpol /set /subcategory:"Special Logon" /success:enable
+auditpol /set /subcategory:"Other Logon/Logoff Events" /success:enable /failure:enable
+
+# Object access
+auditpol /set /subcategory:"File System" /success:enable /failure:enable
+auditpol /set /subcategory:"Registry" /success:enable /failure:enable
+auditpol /set /subcategory:"Filtering Platform Connection" /success:enable /failure:enable
+
+# Privilege use
+auditpol /set /subcategory:"Sensitive Privilege Use" /success:enable /failure:enable
+
+# Account management
+auditpol /set /subcategory:"User Account Management" /success:enable /failure:enable
+auditpol /set /subcategory:"Security Group Management" /success:enable /failure:enable
+
+# Policy change
+auditpol /set /subcategory:"Audit Policy Change" /success:enable /failure:enable
+auditpol /set /subcategory:"Authentication Policy Change" /success:enable
+
+# System events
+auditpol /set /subcategory:"Security State Change" /success:enable /failure:enable
+auditpol /set /subcategory:"Security System Extension" /success:enable /failure:enable
+
+# Include command line in process creation events (4688)
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit" /v ProcessCreationIncludeCmdLine_Enabled /t REG_DWORD /d 1 /f
+```
+
+## 3. Enable PowerShell Logging
+
+```powershell
+# Module logging
+New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging" -Force | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging" -Name EnableModuleLogging -Value 1
+New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging\ModuleNames" -Force | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging\ModuleNames" -Name "*" -Value "*"
+
+# Script block logging
+New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" -Force | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" -Name EnableScriptBlockLogging -Value 1
+```
+
+## 4. Increase Event Log Sizes
+
+The defaults are too small for meaningful retention:
+
+```powershell
+wevtutil sl Security /ms:1073741824                                # 1 GB
+wevtutil sl System /ms:268435456                                   # 256 MB
+wevtutil sl Application /ms:268435456                              # 256 MB
+wevtutil sl "Microsoft-Windows-Sysmon/Operational" /ms:1073741824  # 1 GB
+wevtutil sl "Microsoft-Windows-PowerShell/Operational" /ms:268435456  # 256 MB
+wevtutil sl "Windows PowerShell" /ms:268435456                     # 256 MB
+```
+
+## 5. Install Reveald
+
+Download the latest Windows release from the
+[releases page](https://github.com/runreveal/reveald/releases):
+
+```powershell
+# Create install directory
+New-Item -Path "C:\reveald" -ItemType Directory -Force | Out-Null
+
+# Download and extract (replace VERSION with the latest release)
+Invoke-WebRequest -Uri "https://github.com/runreveal/reveald/releases/download/VERSION/reveald-windows-amd64.zip" -OutFile "$env:TEMP\reveald.zip"
+Expand-Archive -Path "$env:TEMP\reveald.zip" -DestinationPath "C:\reveald" -Force
+```
+
+## 6. Configure Reveald
+
+Create `C:\reveald\config.json`. See
+[config_windows.json](config_windows.json) for a full example.
+
+Replace `{{YOUR_WEBHOOK_URL}}` with your RunReveal reveald source webhook URL:
+
+```json
+{
+  "sources": {
+    "sysmon": {
+      "type": "eventlog",
+      "channel": "Microsoft-Windows-Sysmon/Operational",
+      "query": "*"
+    },
+    "security": {
+      "type": "eventlog",
+      "channel": "Security",
+      "query": "*"
+    },
+    "system": {
+      "type": "eventlog",
+      "channel": "System",
+      "query": "*"
+    },
+    "powershell": {
+      "type": "eventlog",
+      "channel": "Microsoft-Windows-PowerShell/Operational",
+      "query": "*"
+    },
+    "powershell_classic": {
+      "type": "eventlog",
+      "channel": "Windows PowerShell",
+      "query": "*"
+    }
+  },
+  "destinations": {
+    "runreveal": {
+      "type": "runreveal",
+      "webhookURL": "YOUR_WEBHOOK_URL",
+      "batchSize": 100,
+      "flushFreq": "10s"
+    }
+  }
+}
+```
+
+The `query` field accepts XPath 1.0 expressions if you want to filter events at
+the source. For example, to collect only interactive logon events:
+
+```
+*[EventData[Data[@Name='LogonType']='2'] and System[(EventID=4624)]]
+```
+
+## 7. Test
+
+Verify the config works before installing as a service:
+
+```powershell
+C:\reveald\reveald.exe run --config C:\reveald\config.json
+```
+
+You should see log output indicating each event log channel is configured and
+events should start appearing in your RunReveal workspace within seconds.
+
+## 8. Install as a Windows Service
+
+Reveald implements the Windows Service Control Manager (SCM) protocol natively
+and can be registered directly with `sc.exe`:
+
+```powershell
+sc.exe create reveald binPath= "C:\reveald\reveald.exe run --config C:\reveald\config.json" start= auto DisplayName= "RunReveal reveald"
+sc.exe description reveald "RunReveal log collection agent"
+sc.exe failure reveald reset= 60 actions= restart/5000/restart/10000/restart/30000
+
+Start-Service reveald
+```
+
+Verify it's running:
+
+```powershell
+Get-Service reveald
+```
+
+## What You Get
+
+| Source | Key Events |
+|--------|-----------|
+| Sysmon | Process creation with command lines and parent chains, network connections tied to processes, DNS queries, file/registry changes, DLL loads, named pipes, WMI activity |
+| Security | Logon/logoff (4624/4634), process creation (4688) with command lines, privilege use, account and group changes, audit policy changes |
+| System | Service installs, driver loads, system errors |
+| PowerShell | Script block execution, module loading |
+
+## Troubleshooting
+
+Check the Windows System event log for service start/stop errors:
+
+```powershell
+Get-WinEvent -LogName System -FilterXPath "*[System[Provider[@Name='Service Control Manager'] and EventData[Data='reveald']]]" -MaxEvents 10
+```
+
+Verify Sysmon is generating events:
+
+```powershell
+Get-WinEvent -LogName "Microsoft-Windows-Sysmon/Operational" -MaxEvents 5
+```
+
+Restart the service after config changes:
+
+```powershell
+Restart-Service reveald
+```

--- a/examples/windows/config_windows.json
+++ b/examples/windows/config_windows.json
@@ -1,15 +1,37 @@
 {
-  "pprof": "localhost:6060",
-  "sources": [
-    {
+  "sources": {
+    "sysmon": {
+      "type": "eventlog",
+      "channel": "Microsoft-Windows-Sysmon/Operational",
+      "query": "*",
+    },
+    "security": {
       "type": "eventlog",
       "channel": "Security",
-      "query": "*", //"*[EventData[Data[@Name='LogonType']='2'] and System[(EventID=4624)]]"
+      "query": "*",
     },
-  ],
-  "destinations": [
-    {
-      "type": "printer",
+    "system": {
+      "type": "eventlog",
+      "channel": "System",
+      "query": "*",
     },
-  ],
+    "powershell": {
+      "type": "eventlog",
+      "channel": "Microsoft-Windows-PowerShell/Operational",
+      "query": "*",
+    },
+    "powershell_classic": {
+      "type": "eventlog",
+      "channel": "Windows PowerShell",
+      "query": "*",
+    },
+  },
+  "destinations": {
+    "runreveal": {
+      "type": "runreveal",
+      "webhookURL": "{{YOUR_WEBHOOK_URL}}",
+      "batchSize": 100,
+      "flushFreq": "10s",
+    },
+  },
 }

--- a/internal/sources/windows/event.go
+++ b/internal/sources/windows/event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/runreveal/reveald/internal/types"
@@ -115,7 +116,16 @@ func (xe *xmlEvent) ToJSONEvent() *Event {
 		if d.Name != "" {
 			event.EventDataMap[d.Name] = d.Value
 		} else {
-			event.EventData = append(event.EventData, d.Value)
+			// Try to parse key=value pairs from unnamed Data elements.
+			// Some providers (e.g. PowerShell classic) emit data as
+			// tab/newline-delimited "Key=Value" strings.
+			if parsed := parseKeyValuePairs(d.Value); len(parsed) > 0 {
+				for k, v := range parsed {
+					event.EventDataMap[k] = v
+				}
+			} else {
+				event.EventData = append(event.EventData, d.Value)
+			}
 		}
 	}
 	event.UserData = xe.UserData
@@ -178,6 +188,33 @@ type Event struct {
 func newEvent() (el Event) {
 	el.EventDataMap = make(map[string]string)
 	return el
+}
+
+// parseKeyValuePairs attempts to parse a string containing key=value pairs
+// separated by newlines, tabs, or carriage returns (common in PowerShell
+// classic event logs). Returns nil if fewer than 2 pairs are found, so
+// that plain text data falls through to eventData as before.
+func parseKeyValuePairs(s string) map[string]string {
+	result := make(map[string]string)
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k != "" {
+			result[k] = v
+		}
+	}
+	if len(result) < 2 {
+		return nil
+	}
+	return result
 }
 
 func (evt *Event) ToGeneric() (*types.Event, error) {

--- a/internal/sources/windows/event_test.go
+++ b/internal/sources/windows/event_test.go
@@ -1,0 +1,196 @@
+package windows
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestParseKeyValuePairs(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   map[string]string
+		wantNi bool // want nil
+	}{
+		{
+			name:  "powershell classic format",
+			input: "\tDetailSequence=1\r\n\tDetailTotal=1\r\n\r\n\tSequenceNumber=543\r\n\r\n\tUserId=WORKGROUP\\SYSTEM\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.17763.6414\r\n",
+			want: map[string]string{
+				"DetailSequence": "1",
+				"DetailTotal":    "1",
+				"SequenceNumber": "543",
+				"UserId":         "WORKGROUP\\SYSTEM",
+				"HostName":       "ConsoleHost",
+				"HostVersion":    "5.1.17763.6414",
+			},
+		},
+		{
+			name:   "plain text no pairs",
+			input:  "Write-Output \"hello world\"\n",
+			wantNi: true,
+		},
+		{
+			name:   "single pair below threshold",
+			input:  "\tKey=Value\r\n",
+			wantNi: true,
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			wantNi: true,
+		},
+		{
+			name:  "value containing equals sign",
+			input: "\tCommandLine=powershell -c \"1+1=2\"\r\n\tUser=SYSTEM\r\n",
+			want: map[string]string{
+				"CommandLine": "powershell -c \"1+1=2\"",
+				"User":        "SYSTEM",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKeyValuePairs(tt.input)
+			if tt.wantNi {
+				if got != nil {
+					t.Errorf("parseKeyValuePairs() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("parseKeyValuePairs() = nil, want non-nil")
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("parseKeyValuePairs() returned %d pairs, want %d", len(got), len(tt.want))
+			}
+			for k, wantV := range tt.want {
+				if gotV, ok := got[k]; !ok {
+					t.Errorf("missing key %q", k)
+				} else if gotV != wantV {
+					t.Errorf("key %q = %q, want %q", k, gotV, wantV)
+				}
+			}
+		})
+	}
+}
+
+func TestToJSONEvent_NamedData(t *testing.T) {
+	// Sysmon-style XML with named Data elements
+	input := `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+		<System>
+			<Provider Name="Microsoft-Windows-Sysmon" Guid="{5770385f-c22a-43e0-bf4c-06f5698ffbd9}"/>
+			<EventID>1</EventID>
+			<Channel>Microsoft-Windows-Sysmon/Operational</Channel>
+			<Computer>WORKSTATION</Computer>
+			<TimeCreated SystemTime="2026-03-27T21:00:00.000Z"/>
+			<Security UserID="S-1-5-18"/>
+		</System>
+		<EventData>
+			<Data Name="Image">C:\Windows\System32\cmd.exe</Data>
+			<Data Name="CommandLine">cmd.exe /c dir</Data>
+			<Data Name="User">SYSTEM</Data>
+		</EventData>
+	</Event>`
+
+	var xe xmlEvent
+	if err := xml.Unmarshal([]byte(input), &xe); err != nil {
+		t.Fatal(err)
+	}
+
+	event := xe.ToJSONEvent()
+
+	if len(event.EventData) != 0 {
+		t.Errorf("EventData should be empty, got %v", event.EventData)
+	}
+	if got := event.EventDataMap["Image"]; got != `C:\Windows\System32\cmd.exe` {
+		t.Errorf("EventDataMap[Image] = %q", got)
+	}
+	if got := event.EventDataMap["CommandLine"]; got != "cmd.exe /c dir" {
+		t.Errorf("EventDataMap[CommandLine] = %q", got)
+	}
+}
+
+func TestToJSONEvent_UnnamedKeyValueData(t *testing.T) {
+	// PowerShell classic style — unnamed Data with key=value content
+	input := `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+		<System>
+			<Provider Name="PowerShell" Guid=""/>
+			<EventID>800</EventID>
+			<Channel>Windows PowerShell</Channel>
+			<Computer>WORKSTATION</Computer>
+			<TimeCreated SystemTime="2026-03-27T21:00:00.000Z"/>
+			<Security UserID=""/>
+		</System>
+		<EventData>
+			<Data>some script text</Data>
+			<Data>	DetailSequence=1
+	DetailTotal=1
+
+	SequenceNumber=543
+
+	UserId=WORKGROUP\SYSTEM
+	HostName=ConsoleHost
+	HostVersion=5.1.17763.6414
+</Data>
+		</EventData>
+	</Event>`
+
+	var xe xmlEvent
+	if err := xml.Unmarshal([]byte(input), &xe); err != nil {
+		t.Fatal(err)
+	}
+
+	event := xe.ToJSONEvent()
+
+	// The first Data element is plain text (no key=value pairs), should stay in EventData
+	if len(event.EventData) != 1 {
+		t.Errorf("EventData length = %d, want 1", len(event.EventData))
+	}
+	if len(event.EventData) > 0 && event.EventData[0] != "some script text" {
+		t.Errorf("EventData[0] = %q, want %q", event.EventData[0], "some script text")
+	}
+
+	// The second Data element has key=value pairs, should be parsed into EventDataMap
+	if got := event.EventDataMap["HostName"]; got != "ConsoleHost" {
+		t.Errorf("EventDataMap[HostName] = %q, want %q", got, "ConsoleHost")
+	}
+	if got := event.EventDataMap["UserId"]; got != `WORKGROUP\SYSTEM` {
+		t.Errorf("EventDataMap[UserId] = %q, want %q", got, `WORKGROUP\SYSTEM`)
+	}
+	if got := event.EventDataMap["DetailSequence"]; got != "1" {
+		t.Errorf("EventDataMap[DetailSequence] = %q, want %q", got, "1")
+	}
+}
+
+func TestToJSONEvent_UnnamedPlainTextOnly(t *testing.T) {
+	// Data elements that are plain text should remain in EventData
+	input := `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+		<System>
+			<Provider Name="TestProvider" Guid=""/>
+			<EventID>1000</EventID>
+			<Channel>Application</Channel>
+			<Computer>WORKSTATION</Computer>
+			<TimeCreated SystemTime="2026-03-27T21:00:00.000Z"/>
+			<Security UserID=""/>
+		</System>
+		<EventData>
+			<Data>Hello, World!</Data>
+			<Data>Another message</Data>
+		</EventData>
+	</Event>`
+
+	var xe xmlEvent
+	if err := xml.Unmarshal([]byte(input), &xe); err != nil {
+		t.Fatal(err)
+	}
+
+	event := xe.ToJSONEvent()
+
+	if len(event.EventData) != 2 {
+		t.Errorf("EventData length = %d, want 2", len(event.EventData))
+	}
+	if len(event.EventDataMap) != 0 {
+		t.Errorf("EventDataMap should be empty, got %v", event.EventDataMap)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement native Windows Service Control Manager (SCM) protocol so reveald can run as a Windows service directly via `sc.exe` — no NSSM wrapper needed
- Parse key=value pairs from unnamed `EventData` elements (e.g. PowerShell classic logs) into `eventDataMap` instead of leaving them as raw strings in `eventData`
- Add Windows setup documentation and full 5-channel example config (Sysmon, Security, System, PowerShell Operational, PowerShell Classic)

## Test plan
- [x] `parseKeyValuePairs` unit tests pass (5 cases: PowerShell format, plain text, single pair, empty, equals in value)
- [x] `ToJSONEvent` XML-to-Event conversion tests pass (named data, unnamed key-value, unnamed plain text)
- [x] Darwin build succeeds (`go build ./cmd/reveald/`)
- [x] Windows cross-compile succeeds (`GOOS=windows GOARCH=amd64 CGO_ENABLED=1`)
- [x] Deployed and verified running as native Windows service on EC2 test instance
- [x] Confirmed event logs flowing to RunReveal workspace