### PR TITLE
feat: multi-arch Docker image builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     if: github.event.inputs.ref != '' || github.event.inputs.confirm == 'yes'
     outputs:
       tag: ${{ steps.version.outputs.next_version }}
+      ref: ${{ steps.version.outputs.ref }}
       is_release: ${{ steps.version.outputs.is_release }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -39,9 +40,12 @@ jobs:
           INPUT_REF: ${{ github.event.inputs.ref }}
         run: |
           if [ -n "$INPUT_REF" ]; then
-            echo "next_version=$INPUT_REF" >> $GITHUB_OUTPUT
+            # Sanitise ref for use as a Docker tag (replace / with -)
+            safe_tag=$(echo "$INPUT_REF" | sed 's|/|-|g')
+            echo "next_version=$safe_tag" >> $GITHUB_OUTPUT
+            echo "ref=$INPUT_REF" >> $GITHUB_OUTPUT
             echo "is_release=false" >> $GITHUB_OUTPUT
-            echo "Using provided ref: $INPUT_REF"
+            echo "Using provided ref: $INPUT_REF (tag: $safe_tag)"
             exit 0
           fi
 
@@ -69,6 +73,7 @@ jobs:
           fi
 
           echo "next_version=$next_version" >> $GITHUB_OUTPUT
+          echo "ref=$next_version" >> $GITHUB_OUTPUT
           echo "Next version: $next_version"
 
       - name: Verify tag does not exist
@@ -94,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.version.outputs.ref }}
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
@@ -107,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.version.outputs.ref }}
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
@@ -125,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.version.outputs.ref }}
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Login to ghcr.io
@@ -170,7 +175,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.version.outputs.ref }}
       - run: git fetch --force --tags
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ needs.version.outputs.tag }}
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Login to ghcr.io
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
@@ -149,10 +151,14 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ needs.version.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # ── Stage 4: Publish CLI binaries via goreleaser (releases only) ───────
   release-cli:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /reveald ./cmd/reveald/
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /reveald ./cmd/reveald/
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /reveald /reveald


### PR DESCRIPTION
## Summary
- Re-adds buildx + QEMU to the release workflow for `linux/amd64` and `linux/arm64` image builds
- Fixes the GHCR 403 error with `provenance: false` — the root cause was provenance attestations, not credential isolation
- Updates Dockerfile to use Go cross-compilation (`--platform=$BUILDPLATFORM` + `TARGETOS`/`TARGETARCH`) for fast native builds
- Re-enables GHA layer caching

## Test plan
- [x] Trigger workflow_dispatch with `ref: ryank/multi-arch-docker` to test without creating a release
- [x] Verify multi-arch manifest: `docker manifest inspect ghcr.io/runreveal/reveald:ryank-multi-arch-docker`
- [x] Pull and run on Apple Silicon to confirm arm64 works natively

🤖 Generated with [Claude Code](https://claude.com/claude-code)