### PR TITLE
Update kawa to v2-experimental

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.0
 	github.com/carlmjohnson/requests v0.23.4
-	github.com/runreveal/kawa v0.2.2-0.20250409213345-1daf28245005
+	github.com/runreveal/kawa v0.2.4-0.20260402053122-a4207087fb00
 	github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c
 	github.com/runreveal/lib/loader v0.0.0-20250907195919-d96a7be32404
 	github.com/segmentio/ksuid v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/runreveal/kawa v0.2.2-0.20250409213345-1daf28245005 h1:Zf49xgnUpEkTRrI90oTgHnKZvmNRXygObAKcIl3S+5A=
-github.com/runreveal/kawa v0.2.2-0.20250409213345-1daf28245005/go.mod h1:CCLVlTR7O0eqpQGju6hmuSSMKFYdlM9Sdns1N2h1VW0=
+github.com/runreveal/kawa v0.2.4-0.20260402053122-a4207087fb00 h1:rh6KgIFZHgKPS+d+eJM5v7iJKvMgqxzr2a24CiJDrtQ=
+github.com/runreveal/kawa v0.2.4-0.20260402053122-a4207087fb00/go.mod h1:CCLVlTR7O0eqpQGju6hmuSSMKFYdlM9Sdns1N2h1VW0=
 github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c h1:rZt9vvUOA1CstxYueKfaAU7zcLx5PyMSECtJGscP8wo=
 github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c/go.mod h1:qnRPgJExa5ziREWvAhSDMMTBSxBk9wX4D2xZBUBldmw=
 github.com/runreveal/lib/loader v0.0.0-20250907195919-d96a7be32404 h1:gMleQ0wO45/Hrx0qRTZyH+Kbk+/v5tpCopxoEVBoi1I=

--- a/internal/destinations/mqtt/mqtt.go
+++ b/internal/destinations/mqtt/mqtt.go
@@ -24,12 +24,6 @@ func (p *MQTT) Run(ctx context.Context) error {
 	return p.wrapped.Run(ctx)
 }
 
-func (p *MQTT) Send(ctx context.Context, ack func(), msg ...kawa.Message[types.Event]) error {
-	for _, m := range msg {
-		err := p.wrapped.Send(ctx, ack, kawa.Message[[]byte]{Value: m.Value.RawLog})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func (p *MQTT) Send(ctx context.Context, ack func(), msg kawa.Message[types.Event]) error {
+	return p.wrapped.Send(ctx, ack, kawa.Message[[]byte]{Value: msg.Value.RawLog})
 }

--- a/internal/destinations/objbatch/s3.go
+++ b/internal/destinations/objbatch/s3.go
@@ -77,8 +77,8 @@ func (s *ObjectStorage) Run(ctx context.Context) error {
 	return s.batcher.Run(ctx)
 }
 
-func (s *ObjectStorage) Send(ctx context.Context, ack func(), msgs ...kawa.Message[types.Event]) error {
-	return s.batcher.Send(ctx, ack, msgs...)
+func (s *ObjectStorage) Send(ctx context.Context, ack func(), msg kawa.Message[types.Event]) error {
+	return s.batcher.Send(ctx, ack, msg)
 }
 
 func (s *ObjectStorage) Flush(ctx context.Context, msgs []kawa.Message[types.Event]) error {

--- a/internal/destinations/printer/printer.go
+++ b/internal/destinations/printer/printer.go
@@ -17,12 +17,6 @@ func NewPrinter(writer io.Writer) *Printer {
 	return &Printer{wrapped: printer.NewPrinter(writer)}
 }
 
-func (p *Printer) Send(ctx context.Context, ack func(), msg ...kawa.Message[types.Event]) error {
-	for _, m := range msg {
-		err := p.wrapped.Send(ctx, ack, kawa.Message[[]byte]{Value: m.Value.RawLog})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func (p *Printer) Send(ctx context.Context, ack func(), msg kawa.Message[types.Event]) error {
+	return p.wrapped.Send(ctx, ack, kawa.Message[[]byte]{Value: msg.Value.RawLog})
 }

--- a/internal/destinations/runreveal/runreveal.go
+++ b/internal/destinations/runreveal/runreveal.go
@@ -91,8 +91,8 @@ func (r *RunReveal) Run(ctx context.Context) error {
 	return r.batcher.Run(ctx)
 }
 
-func (r *RunReveal) Send(ctx context.Context, ack func(), msgs ...kawa.Message[types.Event]) error {
-	return r.batcher.Send(ctx, ack, msgs...)
+func (r *RunReveal) Send(ctx context.Context, ack func(), msg kawa.Message[types.Event]) error {
+	return r.batcher.Send(ctx, ack, msg)
 }
 
 func (r *RunReveal) newReq() *requests.Builder {

--- a/internal/destinations/s3/s3.go
+++ b/internal/destinations/s3/s3.go
@@ -20,12 +20,6 @@ func (p *S3) Run(ctx context.Context) error {
 	return p.wrapped.Run(ctx)
 }
 
-func (p *S3) Send(ctx context.Context, ack func(), msg ...kawa.Message[types.Event]) error {
-	for _, m := range msg {
-		err := p.wrapped.Send(ctx, ack, kawa.Message[[]byte]{Value: m.Value.RawLog})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func (p *S3) Send(ctx context.Context, ack func(), msg kawa.Message[types.Event]) error {
+	return p.wrapped.Send(ctx, ack, kawa.Message[[]byte]{Value: msg.Value.RawLog})
 }


### PR DESCRIPTION
## Summary
- Upgrade `github.com/runreveal/kawa` to v2-experimental branch (`v0.2.4-0.20260402053122-a4207087fb00`)
- Update all 5 destination `Send` methods from variadic `...kawa.Message[T]` to single `kawa.Message[T]` to match the new interface
- s3, printer, mqtt: removed loop, now direct pass-through of single message
- objbatch, runreveal: forward single message to batcher without spread

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes