### PR TITLE
feat: update kawa to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.85.0
 	github.com/carlmjohnson/requests v0.23.4
-	github.com/runreveal/kawa v0.2.4-0.20260416024739-9c856d848e60
+	github.com/runreveal/kawa v0.3.0
 	github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c
 	github.com/runreveal/lib/cli v0.0.0-20260407050128-6c664049954d
 	github.com/runreveal/lib/loader v0.0.0-20250907195919-d96a7be32404

--- a/go.sum
+++ b/go.sum
@@ -68,10 +68,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/runreveal/kawa v0.2.4-0.20260402053122-a4207087fb00 h1:rh6KgIFZHgKPS+d+eJM5v7iJKvMgqxzr2a24CiJDrtQ=
-github.com/runreveal/kawa v0.2.4-0.20260402053122-a4207087fb00/go.mod h1:CCLVlTR7O0eqpQGju6hmuSSMKFYdlM9Sdns1N2h1VW0=
-github.com/runreveal/kawa v0.2.4-0.20260416024739-9c856d848e60 h1:mn1Ky7X1/I9gV3QasIPVpdeX1hq5Hmb7ugn/kPURu/o=
-github.com/runreveal/kawa v0.2.4-0.20260416024739-9c856d848e60/go.mod h1:CCLVlTR7O0eqpQGju6hmuSSMKFYdlM9Sdns1N2h1VW0=
+github.com/runreveal/kawa v0.3.0 h1:CCqckk2lAIGutXqBWQapk80LbxvkpBGaqc1u+9IVxRM=
+github.com/runreveal/kawa v0.3.0/go.mod h1:Z5lMpLqwtpbg2v3458Wf8oKZWRS2e0xMDyS8F3Rojqw=
 github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c h1:rZt9vvUOA1CstxYueKfaAU7zcLx5PyMSECtJGscP8wo=
 github.com/runreveal/lib/await v0.0.0-20231128193746-50c2ad68891c/go.mod h1:qnRPgJExa5ziREWvAhSDMMTBSxBk9wX4D2xZBUBldmw=
 github.com/runreveal/lib/cli v0.0.0-20260407050128-6c664049954d h1:VsRgsD4DJnQrB4FMa7dLbEuspgyvi34BfrR9N6KNj1w=


### PR DESCRIPTION
## Summary
- Update kawa dependency from v2-experimental pre-release to the merged v0.3.0 release

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes